### PR TITLE
Add CI testing using travis-ci and appveyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ node_js:
   - "6"
   - "8"
 before_install:
-  - 'if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew tap homebrew/homebrew-php; fi'
-  - 'if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi'
+  - 'if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then travis_wait brew tap homebrew/homebrew-php; fi'
+  - 'if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then travis_wait brew update; fi'
   - 'if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then travis_wait 30 brew install --with-cgi php71; fi'
   - 'if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PATH="$(brew --prefix homebrew/php/php71)/bin:$PATH"; fi'
   - export PHP_PATH="$(which php-cgi)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+os:
+  - linux
+  - osx
+language: node_js
+node_js:
+  - "4"
+  - "6"
+  - "8"
+before_install:
+  - 'if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew tap homebrew/homebrew-php; fi'
+  - 'if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi'
+  - 'if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then travis_wait 30 brew install --with-cgi php71; fi'
+  - 'if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PATH="$(brew --prefix homebrew/php/php71)/bin:$PATH"; fi'
+  - export PHP_PATH="$(which php-cgi)"
+  - echo $PHP_PATH
+  - php-cgi -v
+addons:
+  apt:
+    sources:
+    - sourceline: 'ppa:ondrej/php'
+    packages:
+    - php7.1-cgi

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ before_install:
 addons:
   apt:
     sources:
+    - ubuntu-toolchain-r-test
     - sourceline: 'ppa:ondrej/php'
     packages:
+    - g++-4.8
     - php7.1-cgi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,32 @@
+version: 'test-{build}'
+environment:
+  matrix:
+    - nodejs_version: '4'
+    - nodejs_version: '6'
+    - nodejs_version: '8'
+platform:
+  - x86
+  - x64
+cache:
+    - c:\php -> appveyor.yml
+init:
+    - SET PATH=c:\php\71;%PATH%
+    - SET PHP_PATH=c:\php\71\php-cgi.exe
+clone_folder: 'c:\projects\%APPVEYOR_PROJECT_NAME%'
+install:
+  - IF EXIST c:\php\71 (SET PHP=0) ELSE (SET PHP=1)
+  - IF %PHP%==1 mkdir c:\php\71
+  - IF %PHP%==1 cd c:\php\71
+  - IF %PHP%==1 appveyor DownloadFile http://windows.php.net/downloads/releases/archives/php-7.1.0-Win32-VC14-x64.zip
+  - IF %PHP%==1 7z x php-7.1.0-Win32-VC14-x64.zip >nul
+  - set PATH=c:\php\71\;%PATH%
+  - c:\php\71\php-cgi.exe -v
+  - cd c:\projects\%APPVEYOR_PROJECT_NAME%
+  - ps: 'Install-Product node $env:nodejs_version $env:platform'
+  - npm install
+test_script:
+  - echo %cd%
+  - node --version
+  - npm --version
+  - npm test
+build: 'off'

--- a/package.json
+++ b/package.json
@@ -32,11 +32,17 @@
     "express": "^4",
     "express-session": "^1",
     "body-parser": "^1",
-    "ws": "^3"
+    "ws": "^3",
+    "mocha": "^4.1.0",
+    "chai": "^4.1.2",
+    "request": "^2.69.0"
   },
   "peerDependencies": {},
   "directories": {
     "example": "example"
+  },
+  "scripts": {
+    "test": "node node_modules/mocha/bin/mocha --exit"
   },
   "dependencies": {
     "body-parser": "^1",

--- a/test/doc_root/phpinfo.php
+++ b/test/doc_root/phpinfo.php
@@ -1,0 +1,3 @@
+<?php
+    phpinfo();
+?>

--- a/test/testexpress.js
+++ b/test/testexpress.js
@@ -7,11 +7,11 @@ var request = require('request');
 var express = require('express');
 var sphp = require('../sphp');
 
+var serving = false;
 describe('Test Express only', function() {
     before('Setup Server', function (_done) {
         this.timeout(600000); // because of first install from npm
 
-        var serving = false;
         var app = express();
         if (process.env.PHP_PATH && process.env.PHP_PATH !== "") {
             sphp.cgiEngine = process.env.PHP_PATH;

--- a/test/testexpress.js
+++ b/test/testexpress.js
@@ -4,7 +4,7 @@ var expect = require('chai').expect;
 var request = require('request');
 
 var express = require('express');
-var sphp = require('sphp');
+var sphp = require('../sphp');
 
 describe('Test Express only', function() {
     before('Setup Server', function (_done) {

--- a/test/testexpress.js
+++ b/test/testexpress.js
@@ -16,13 +16,14 @@ describe('Test Express only', function() {
             sphp.cgiEngine = process.env.PHP_PATH;
         }
 
+        var doc_root = __dirname + path.sep + 'doc_root/';
         var server = app.listen(20000, function() {
-            console.log('SPHP Server started on port 20000 with Doc-Root doc_root');
+            console.log('SPHP Server started on port 20000 with Doc-Root ' + doc_root);
             serving = true;
         });
 
-        app.use(sphp.express('doc_root'));
-        app.use(express.static('doc_root'));
+        app.use(sphp.express(doc_root));
+        app.use(express.static(doc_root));
 
         _done();
     });

--- a/test/testexpress.js
+++ b/test/testexpress.js
@@ -1,0 +1,54 @@
+/* jshint -W097 */// jshint strict:false
+/*jslint node: true */
+var expect = require('chai').expect;
+var request = require('request');
+
+var express = require('express');
+var sphp = require('sphp');
+
+describe('Test Express only', function() {
+    before('Setup Server', function (_done) {
+        this.timeout(600000); // because of first install from npm
+
+        var serving = false;
+        var app = express();
+        if (process.env.PHP_PATH && process.env.PHP_PATH !== "") {
+            sphp.cgiEngine = process.env.PHP_PATH;
+        }
+
+        var server = app.listen(20000, function() {
+            console.log.info('SPHP Server started on port 20000 with Doc-Root doc_root');
+            serving = true;
+        });
+
+        app.use(sphp.express('doc_root'));
+        app.use(express.static('doc_root'));
+
+        _done();
+    });
+
+    it('Test phpinfo()', function (done) {
+        request('http://127.0.0.1:20000/phpinfo.php', function (error, response, body) {
+            console.log('BODY: ' + body);
+            expect(serving).to.be.true;
+            expect(error).to.be.not.ok;
+            expect(body.indexOf('<title>phpinfo()</title>')).to.be.not.equal(-1);
+            expect(response.statusCode).to.equal(200);
+            done();
+        });
+    });
+
+    after('Stop Server', function (done) {
+        this.timeout(10000);
+        try {
+            if (serving) {
+                app.close();
+                console.log.info('SPHP Server stopped');
+            }
+            if (callback) callback();
+        } catch (e) {
+            if (callback) callback();
+        }
+
+    });
+});

--- a/test/testexpress.js
+++ b/test/testexpress.js
@@ -17,7 +17,7 @@ describe('Test Express only', function() {
         }
 
         var server = app.listen(20000, function() {
-            console.log.info('SPHP Server started on port 20000 with Doc-Root doc_root');
+            console.log('SPHP Server started on port 20000 with Doc-Root doc_root');
             serving = true;
         });
 
@@ -43,12 +43,10 @@ describe('Test Express only', function() {
         try {
             if (serving) {
                 app.close();
-                console.log.info('SPHP Server stopped');
+                console.log('SPHP Server stopped');
             }
-            if (callback) callback();
         } catch (e) {
-            if (callback) callback();
         }
-
+        done();
     });
 });

--- a/test/testexpress.js
+++ b/test/testexpress.js
@@ -1,6 +1,7 @@
 /* jshint -W097 */// jshint strict:false
 /*jslint node: true */
 var expect = require('chai').expect;
+var path = require('path');
 var request = require('request');
 
 var express = require('express');


### PR DESCRIPTION
As promised here is a pull request that adds CI testing.
Current Results:
Linux/Mac (Green): https://travis-ci.org/Apollon77/sphp/builds/326444504
Windows (Red): https://ci.appveyor.com/project/Apollon77/sphp/build/test-7

I only added one very simple test that opens a port and requests phpinfo. But with this example you can see how testing works and you can add more testings (simply copy the testexpress.js file in directory "test" and create additional files, they all will be executed).
Tests are run automatically with each commit, so you can see after each commit if it broke something.

To enable testing you need to use your GitHub Account to register with travis-ci.org and ci.appveyor.com, then click on Account (Travis-CI) or Projects(Appveyor) to add your Github project. Then you need to do the first commit, so one idea would be to enable that before you accept this PR :-))

You may also want to add the test directory and test configs to npm-ignore file. (sorry forgot that)

I will prepare a second PR which hopefully can fix windows compat, but will do some changes and refactorings in sphp.js (including some code-style stiff my IDE did ... but wanted to separe that.