### PR TITLE
Option A: Minimal needed changes to get Windows-compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ node_js:
   - "6"
   - "8"
 before_install:
-  - 'if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew tap homebrew/homebrew-php; fi'
-  - 'if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi'
+  - 'if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then travis_wait brew tap homebrew/homebrew-php; fi'
+  - 'if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then travis_wait brew update; fi'
   - 'if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then travis_wait 30 brew install --with-cgi php71; fi'
   - 'if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PATH="$(brew --prefix homebrew/php/php71)/bin:$PATH"; fi'
   - export PHP_PATH="$(which php-cgi)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+os:
+  - linux
+  - osx
+language: node_js
+node_js:
+  - "4"
+  - "6"
+  - "8"
+before_install:
+  - 'if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew tap homebrew/homebrew-php; fi'
+  - 'if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi'
+  - 'if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then travis_wait 30 brew install --with-cgi php71; fi'
+  - 'if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PATH="$(brew --prefix homebrew/php/php71)/bin:$PATH"; fi'
+  - export PHP_PATH="$(which php-cgi)"
+  - echo $PHP_PATH
+  - php-cgi -v
+addons:
+  apt:
+    sources:
+    - sourceline: 'ppa:ondrej/php'
+    packages:
+    - php7.1-cgi

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ before_install:
 addons:
   apt:
     sources:
+    - ubuntu-toolchain-r-test
     - sourceline: 'ppa:ondrej/php'
     packages:
+    - g++-4.8
     - php7.1-cgi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,32 @@
+version: 'test-{build}'
+environment:
+  matrix:
+    - nodejs_version: '4'
+    - nodejs_version: '6'
+    - nodejs_version: '8'
+platform:
+  - x86
+  - x64
+cache:
+    - c:\php -> appveyor.yml
+init:
+    - SET PATH=c:\php\71;%PATH%
+    - SET PHP_PATH=c:\php\71\php-cgi.exe
+clone_folder: 'c:\projects\%APPVEYOR_PROJECT_NAME%'
+install:
+  - IF EXIST c:\php\71 (SET PHP=0) ELSE (SET PHP=1)
+  - IF %PHP%==1 mkdir c:\php\71
+  - IF %PHP%==1 cd c:\php\71
+  - IF %PHP%==1 appveyor DownloadFile http://windows.php.net/downloads/releases/archives/php-7.1.0-Win32-VC14-x64.zip
+  - IF %PHP%==1 7z x php-7.1.0-Win32-VC14-x64.zip >nul
+  - set PATH=c:\php\71\;%PATH%
+  - c:\php\71\php-cgi.exe -v
+  - cd c:\projects\%APPVEYOR_PROJECT_NAME%
+  - ps: 'Install-Product node $env:nodejs_version $env:platform'
+  - npm install
+test_script:
+  - echo %cd%
+  - node --version
+  - npm --version
+  - npm test
+build: 'off'

--- a/package.json
+++ b/package.json
@@ -32,11 +32,17 @@
     "express": "^4",
     "express-session": "^1",
     "body-parser": "^1",
-    "ws": "^3"
+    "ws": "^3",
+    "mocha": "^4.1.0",
+    "chai": "^4.1.2",
+    "request": "^2.69.0"
   },
   "peerDependencies": {},
   "directories": {
     "example": "example"
+  },
+  "scripts": {
+    "test": "node node_modules/mocha/bin/mocha --exit"
   },
   "dependencies": {
     "body-parser": "^1",

--- a/sphp.js
+++ b/sphp.js
@@ -6,12 +6,12 @@
   Maintain a pool of ready workers for fast responcetime.
 
   Use as express middleware:
-    app.use(sphp.express(<Document root>));  
-  
+    app.use(sphp.express(<Document root>));
+
   or direct call
     sphp.exec
 
-  To attach to websocket server: 
+  To attach to websocket server:
     ws.on('connection',sphp.websocket(<options>));
 
   configure by setting the following variablws:
@@ -20,19 +20,19 @@
     sphp.maxWorkers       defaults to 20
     sphp.stepDowntime     defaults to 360
     sphp.overwriteWSPath  null
-    
-  Aspire to keep compability with scripts written for apache mod_php 
-  Using node session controle and parsing it to PHP 
+
+  Aspire to keep compability with scripts written for apache mod_php
+  Using node session controle and parsing it to PHP
 
   notes:
-    - Websockets has a differant request structure from a static page requests  
+    - Websockets has a differant request structure from a static page requests
 
-    
+
   To do:
     make php-fpm interface
     file upload
     check 404 on php
-    
+
 \*============================================================================*/
 var fs = require('fs');
 var path = require("path");
@@ -70,7 +70,7 @@ sphp.increaseTime=false;
 sphp.maintenance=false;
 
 // Find absolute path to this directory and add script name
-sphp.preBurnerScript=module.filename.substring(0,module.filename.lastIndexOf("/"));
+sphp.preBurnerScript=module.filename.substring(0,module.filename.lastIndexOf(path.sep));
 sphp.preBurnerScript+='/php_worker.php';
 
 // Get PHP version
@@ -86,19 +86,19 @@ child.stdout.on('end', function(){
   Express Middleware to execute a PHP script.
 
   app.use(sphp.express(<PHP document root>));
-  
-  The script is expected to return a complete HTML responce. 
+
+  The script is expected to return a complete HTML responce.
   The response will be partitioned into segments (using callback) of type:
-    status 
+    status
     header
-    data (including stderr) 
+    data (including stderr)
     end
-    error 
-      
+    error
+
 \*============================================================================*/
 sphp.express=function(docRoot){
 
-  // Initiliaze once 
+  // Initiliaze once
   if(sphp.docRoot) sphp.docRoot=docRoot;
 
   // Return middleware function
@@ -111,7 +111,7 @@ sphp.express=function(docRoot){
 
     // Launch script
     sphp.exec(request,function(event,data,param){
-      // console.debug("----Recieving ",event," With: ",data,":",param);    
+      // console.debug("----Recieving ",event," With: ",data,":",param);
       if(!response.finished) switch (event){
       case 'status':
         response.status(data);
@@ -144,7 +144,7 @@ sphp.express=function(docRoot){
 
 /*============================================================================*\
   Execute PHP script
-  
+
   Start a PHP session, by deploying a prespawned worker.
 
   Using the script php_worker.php as a launcher script, to set predefined globals
@@ -153,9 +153,9 @@ sphp.exec=function(request,callback){
   var deployed=false;
   var freeWorker=false;
 
-  // Initiliaze once 
+  // Initiliaze once
   if(!sphp.worker){
-    sphp.worker=[]; 
+    sphp.worker=[];
     sphp.maintain();
   }
 
@@ -185,16 +185,16 @@ sphp.exec=function(request,callback){
           // Release input to worker (Let it run)
           sphp.worker[i].stdin.write(JSON.stringify(sphp.worker[i].proc.conInfo));
           sphp.worker[i].stdin.end();
-          
-          if(process.stdout.isTTY && false) 
+
+          if(process.stdout.isTTY && false)
             console.info("Deploying worker PID: ",sphp.worker[i].pid);
-          
+
           deployed=true;
           break;
         }
       }
 
-      // Too busy 
+      // Too busy
       if(!deployed){
         callback('status',503
           , "Sorry, too busy right now. Please try again later");
@@ -202,20 +202,20 @@ sphp.exec=function(request,callback){
       }
 
     // File not found
-    }else{  
+    }else{
       callback('status',404, "Sorry, unable to locate file: "
         +sphp.docRoot + request._parsedUrl.pathname);
       callback('end');
       console.info("File not found (404): "
         +sphp.docRoot + request._parsedUrl.pathname);
-    }      
-  }); 
+    }
+  });
 }
 
 /*============================================================================*\
   Websocket: Attach on connection event
 
-  Attach a "receive message" event handler 
+  Attach a "receive message" event handler
   If its a php file, execute it
 
   The options are the ones uset to setup express-session:
@@ -232,12 +232,12 @@ sphp.exec=function(request,callback){
     ,rolling: true
     ,name: 'SID'
   }
-  
+
   app.use(expressSession(sessionOptions));
   ws.on('connection',sphp.websocket(sessionOptions));
 
   options: store and name must be set.
-      
+
 \*============================================================================*/
 sphp.websocket = function (opt){
   return function(socket,IncomingMessage) {
@@ -245,54 +245,54 @@ sphp.websocket = function (opt){
 
     if(typeof socket.upgradeReq == 'undefined') // WS 3.0 fix
       socket.upgradeReq = IncomingMessage;
-      
+
     // Handler for incomming messages
     socket.on('message', function(msg){
       var sid;
       var parts;
       //console.info("Received ws message: ",request.body);
 
-      // Create a pseudo request record 
+      // Create a pseudo request record
       var request={
          socket: socket
         ,body:   msg.toString()
       };
 
-      // Parse POST body as JSON to PHP  
+      // Parse POST body as JSON to PHP
       //socket.upgradeReq.headers['Content-Type']="application/json";
-      
+
       //console.log("WS Headers: ",socket.upgradeReq.headers);
-      
+
       // Find session cookie content, by name
       parts=unescape(socket.upgradeReq.headers.cookie).match(
         '(^|;)\\s*' + opt.name + '\\s*=\\s*([^;]+)');
-      //logger.debug("ws session parts: ",parts);        
+      //logger.debug("ws session parts: ",parts);
       if(parts){
         request.sessionID=parts[0].split(/[=.]/)[1];
         // SID is serialised. Use value between s: and . as index (SID)
         if(request.sessionID.substr(0,2) == 's:')
           request.sessionID=request.sessionID.substr(2);
-        
+
         // Find session. Use value between s: and . as index (SID)
         opt.store.get(request.sessionID,function(error,data){
           if(data) request.session=data;
           // Execute php script
-        
+
           sphp.exec(request,function(event,data){
             // Handle returned data
-            if(event=='data' && request.socket.upgradeReq.socket.writable) 
+            if(event=='data' && request.socket.upgradeReq.socket.writable)
               request.socket.send(data);
-              //console.log("Sending:",event,data);            
+              //console.log("Sending:",event,data);
           });
         },request);
 
       // Execute PHP without session
       }else sphp.exec(request,function(event,data){
         // Handle returned data
-        if(event=='data' && request.socket.upgradeReq.socket.writable) 
+        if(event=='data' && request.socket.upgradeReq.socket.writable)
           request.socket.send(data);
-          //console.log("Sending:",event,data);            
-      });      
+          //console.log("Sending:",event,data);
+      });
     });
   }
 }
@@ -301,18 +301,18 @@ sphp.websocket = function (opt){
 Maintain PHP workers
 
 PHP workers are preforked and kept ready, to improve response time.
-The number of workers are determined by the demand. When minSpareWorkers are not 
-met do to demand, it is increased for a time. When it has not been needed for 
-stepDownTime, it is decreased again. 
+The number of workers are determined by the demand. When minSpareWorkers are not
+met do to demand, it is increased for a time. When it has not been needed for
+stepDownTime, it is decreased again.
 
-MinSpareWorkers: When a worker is spend (has run a script) it is terminated. If 
+MinSpareWorkers: When a worker is spend (has run a script) it is terminated. If
 the number of spare workers are below minSpareWorkers, new workers are forked.
 
 Allocating more workers, will only improve response time up to a point. When the
-resources becomes depleted, the only option is to prioritise and queue the 
+resources becomes depleted, the only option is to prioritise and queue the
 requests.
 
-MaxWorkers: the number of workers that will never be exceed. Instead, the 
+MaxWorkers: the number of workers that will never be exceed. Instead, the
 request will be queued for maxWait time. If it expires the request are rejected.
 
 Global variables are transfered via stdin, rather than enviroment variables, in
@@ -321,10 +321,10 @@ php script that populates GLOBALS with data from stdin.
 
 stdin is used to hold the process, until needed.
 
-The list of workers are ordered with the oldest last, so that length reflects 
+The list of workers are ordered with the oldest last, so that length reflects
 the actual number of workers (Using add=>unshift delete=>splice)
 
-Worker array objects layout: 
+Worker array objects layout:
    state: enum ready, running, spend
    time: of last state change
    proc: handle to spawned process
@@ -344,15 +344,15 @@ sphp.maintain=function(){
   for(var i in sphp.worker){
     // Find free workers
     if(sphp.worker[i].proc.state=='ready') spares++
-    if(sphp.worker[i].proc.state=='dead') 
+    if(sphp.worker[i].proc.state=='dead')
       sphp.worker.splice(i,1);
-    else  
+    else
       workers++;
   }
 
-  if(sphp.cminSpareWorkers < sphp.minSpareWorkers) 
+  if(sphp.cminSpareWorkers < sphp.minSpareWorkers)
     sphp.cminSpareWorkers = sphp.minSpareWorkers;
-    
+
   // increase number of workers
   if(spares<1 && workers<sphp.maxWorkers){
     if(sphp.increaseTime) sphp.cminSpareWorkers++;
@@ -381,7 +381,7 @@ sphp.maintain=function(){
     }
 
     // Some process settings
-    sphp.worker[0].stderr.setEncoding('utf-8');  
+    sphp.worker[0].stderr.setEncoding('utf-8');
     sphp.worker[0].stdout.setEncoding('utf-8');
     sphp.worker[0].stdout.parent = sphp.worker[0];
     sphp.worker[0].stderr.parent = sphp.worker[0];
@@ -391,16 +391,16 @@ sphp.maintain=function(){
       ,outBuffer: ''
       ,errorBuffer: ''
     }
-    // console.info("Starting worker PID: " + proc.pid);    
+    // console.info("Starting worker PID: " + proc.pid);
 
-    // Make temporary listners for output (Errors) 
+    // Make temporary listners for output (Errors)
     sphp.worker[0].stdout.on('data', function(data) {
-      if(sphp.worker[0].proc.outBuffer.length<4096) 
+      if(sphp.worker[0].proc.outBuffer.length<4096)
         sphp.worker[0].proc.outBuffer += data.toString();
     });
 
     sphp.worker[0].stderr.on('data', function(data) {
-      if(this.parent.proc.errorBuffer.length<4096) 
+      if(this.parent.proc.errorBuffer.length<4096)
         this.parent.proc.errorBuffer += data.toString();
     });
 
@@ -409,29 +409,29 @@ sphp.maintain=function(){
       if(error && this.proc.state=='ready'){
         FormDebugMessage(this,'exit',error);
         this.proc.state="dead";
-      }  
-      if(this.proc.state!='dead')  
-        process.nextTick(sphp.maintain);  
+      }
+      if(this.proc.state!='dead')
+        process.nextTick(sphp.maintain);
     });
 
     sphp.worker[0].on('error', function (error) {
       if(error && this.proc.state=='ready'){
         FormDebugMessage(this,'error',error);
         this.proc.state="dead";
-      }  
-      if(this.proc.state!='dead')  
-        process.nextTick(sphp.maintain);  
+      }
+      if(this.proc.state!='dead')
+        process.nextTick(sphp.maintain);
     });
 
     workers++;
   }
-  
+
   // repport on workers
   if(process.stdout.isTTY && false){
     console.info("==========================================================================");
     console.info("PHP Workers spares:",spares," min:",sphp.cminSpareWorkers," Max:",sphp.maxWorkers);
 
-    workers=0; spares=0;         
+    workers=0; spares=0;
     for(var i in sphp.worker){
       workers++;
       console.info(i,"PID:",sphp.worker[i].pid," State:",sphp.worker[i].proc.state
@@ -441,22 +441,22 @@ sphp.maintain=function(){
     }
     console.info("==========================================================================");
   }
-  
+
   function FormDebugMessage(worker, event, error){
-//console.debug("FormDebugMessage this",this);  
+//console.debug("FormDebugMessage this",this);
     var str = "PHP worker script ended with error."
     str += "\n  PHP engine: "+sphp.cgiEngine;
-    str += "\n  Preburner script: " + sphp.preBurnerScript; 
+    str += "\n  Preburner script: " + sphp.preBurnerScript;
     //str += "\n  Worker PID: "+worker.pid;
     str+="\n  Error code: " + error;
     if(worker.proc.errorBuffer.length || worker.proc.outBuffer.length){
-      str += "\n  Script error message: " 
-      str += "\n" + worker.proc.outBuffer 
+      str += "\n  Script error message: "
+      str += "\n" + worker.proc.outBuffer
       str += "\n" + worker.proc.errorBuffer;
     }
 //    str += " after "+((new Date).getTime()-worker.proc.time)/1000;
 //    str += " Seconds";
-    throw new Error(str);    
+    throw new Error(str);
   }
 
 }
@@ -464,48 +464,48 @@ sphp.maintain=function(){
 /*============================================================================*\
   Handle output from the spawned process
 
-  request body part and other information are parsed through stdin, to the php 
+  request body part and other information are parsed through stdin, to the php
   process. body including multipart are interpreted by the server, before parsing
-  it to the cgi.  
+  it to the cgi.
   Node provides for the uploaded files to be stored. they only need to be renamed
   and information passed.
- 
-  on reveiving data on stdid, all input is treated as headers, until end of 
+
+  on reveiving data on stdid, all input is treated as headers, until end of
   header section is send (double windows end of line: \n\r\n\r)
-  
+
   Data are received in multi part blocks, with no regard to the content.
   eg. a data block might contain both headers, [end of header] and body
-  
+
   The receiving callback function must have data separated in:
     status, header, data, error and end request.
-  
+
   Status 200 OK is assumed, if not set.
-  
+
   Note: if header contains a redirect (Location) the status must be set accordingly
- 
+
   Quirks:
     1. php-cgi might send error text formatted in HTML before the headers
-      Fix: 1. error messages are stores until headers are send. 
+      Fix: 1. error messages are stores until headers are send.
            2. a default header of Content-type: text/html (overwritten if other))
     2. php-cgi might send a header in one block and the line ending in another
       Fix: buffer all headers until end of header section are received
     3. the phpinfo() function requests pseudo pages for logo images.
 
     for strange 404 see http://woozle.org/~neale/papers/php-cgi.html
- 
+
 \*============================================================================*/
 sphp._responseHandler= function (worker,callback){
   worker.proc.outBuffer='';
   worker.proc.errorBuffer='';
   worker.proc.headersSent = false;
-  worker.proc.headers=''; 
+  worker.proc.headers='';
 
   // Remove listners for workers in idle state
   worker.stdout.removeAllListeners('data');
   worker.stderr.removeAllListeners('data');
   worker.removeAllListeners('error');
   worker.removeAllListeners('exit');
- 
+
   // Catch output from script and send it to client
   worker.stdout.on('data', function(data){
     var worker = this.parent;
@@ -514,7 +514,7 @@ sphp._responseHandler= function (worker,callback){
     if(!worker.proc.headersSent){
       // Store headers until a end of header is received (\r\n\r\n)
       worker.proc.headers += data.toString();
-      
+
       // Pre-process headers: divide headers into lines and separate body data
       var eoh = worker.proc.headers.indexOf('\r\n\r\n');
       var eohLen = 4;
@@ -522,7 +522,7 @@ sphp._responseHandler= function (worker,callback){
         eoh = worker.proc.headers.indexOf('\n\n');
         eohLen = 2;
       }
-      
+
       if(eoh >= 0){
         var line = worker.proc.headers.substr(0,eoh).split('\n');
         var div;
@@ -532,7 +532,7 @@ sphp._responseHandler= function (worker,callback){
           if(div>0){
             var key = line[i].substr(0,div);
             var value = line[i].substr(div+2).replace("\r","");
-// console.log("Sending header 1:",key,":",value);            
+// console.log("Sending header 1:",key,":",value);
             callback('header',key,value);
           }
         }
@@ -544,7 +544,7 @@ sphp._responseHandler= function (worker,callback){
           callback('data',worker.proc.headers.substr(eoh+eohLen));
         }
       }
-    
+
     // Body
     }else{;
       callback('data',data.toString());
@@ -554,27 +554,27 @@ sphp._responseHandler= function (worker,callback){
   // Error. Catch standard error output from script (but don't send it until the end)
   worker.stderr.on('data', (function(worker,callback){
     return function (data) {
-      if(worker.proc.errorBuffer.length<4096) 
+      if(worker.proc.errorBuffer.length<4096)
         worker.proc.errorBuffer += data.toString();
     };
   })(worker,callback));
 
   worker.stdout.on('close', (function(worker,callback){
-    return function () { endWithGrace(worker,callback); }; 
+    return function () { endWithGrace(worker,callback); };
   })(worker,callback));
- 
+
   worker.stderr.on('close', (function(worker,callback){
-    return function () { endWithGrace(worker,callback); }; 
+    return function () { endWithGrace(worker,callback); };
   })(worker,callback));
 
   worker.on('exit', (function(worker,callback){
-    return function () { endWithGrace(worker,callback); }; 
+    return function () { endWithGrace(worker,callback); };
   })(worker,callback));
-  
+
   worker.on('error', (function(worker,callback){
-    return function () { endWithGrace(worker,callback); }; 
+    return function () { endWithGrace(worker,callback); };
   })(worker,callback));
-  
+
   function endWithGrace(worker,callback){
     //console.debug("Closeing event this:",worker);
     if(worker.proc.state == 'running'){
@@ -587,7 +587,7 @@ sphp._responseHandler= function (worker,callback){
       }
       if(worker.proc.outBuffer.length) callback('data',worker.proc.outBuffer);
       if(worker.proc.errorBuffer.length) callback('error',worker.proc.errorBuffer);
-//console.log("--------------------------------------------------------------");      
+//console.log("--------------------------------------------------------------");
       callback('end');
       process.nextTick(sphp.maintain);
     }
@@ -596,7 +596,7 @@ sphp._responseHandler= function (worker,callback){
 
 /*============================================================================*\
   Compose a connection information record on client request
-  
+
 ┌─────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                            href                                             │
 ├──────────┬──┬─────────────────────┬─────────────────────┬───────────────────────────┬───────┤
@@ -620,7 +620,7 @@ sphp._responseHandler= function (worker,callback){
 \*============================================================================*/
 sphp._getConInfo=function(request){
   // Copy predefined super globals
-  var conInfo = JSON.parse(JSON.stringify(sphp.superglobals)); 
+  var conInfo = JSON.parse(JSON.stringify(sphp.superglobals));
 
   /*==========================================================================*\
     Websocket request
@@ -628,13 +628,13 @@ sphp._getConInfo=function(request){
   if(typeof request.socket  == 'object'
       && typeof request.socket.upgradeReq != 'undefined'
       && typeof request.socket.upgradeReq.headers != 'undefined'){
-  
+
     var extReq = request.socket.upgradeReq;
     conInfo._SERVER.REMOTE_PORT = request.socket._socket.remotePort || '';
     conInfo._SERVER.REMOTE_ADDR = request.socket._socket.remoteAddress || '';
     conInfo._SERVER.REQUEST_METHOD = 'websocket';
     conInfo._GET = url.parse(request.socket.upgradeReq.url, true).query;
- 
+
    /*==========================================================================*\
     basic HTTP request
   \*==========================================================================*/
@@ -643,7 +643,7 @@ sphp._getConInfo=function(request){
     var extReq = request;
     conInfo._SERVER.REMOTE_ADDR = request.client.remoteAddress || '';
     conInfo._SERVER.REMOTE_PORT = request.client.remotePort || '';
-    conInfo._SERVER.REQUEST_METHOD = request.method || ''; 
+    conInfo._SERVER.REQUEST_METHOD = request.method || '';
     conInfo._GET = request.query || {};
     conInfo._FILES = {};
     for(var f in request.files){
@@ -658,7 +658,7 @@ sphp._getConInfo=function(request){
   /*==========================================================================*\
   // Non method specifics
   \*==========================================================================*/
-  conInfo._SERVER.SERVER_PROTOCOL = 
+  conInfo._SERVER.SERVER_PROTOCOL =
     extReq.httpVersion ? "HTTP/" + extReq.httpVersion : '';
 
   conInfo._SERVER.DOCUMENT_ROOT = path.resolve(sphp.docRoot);
@@ -669,28 +669,28 @@ sphp._getConInfo=function(request){
 
     conInfo._SERVER.SCRIPT_NAME = request._parsedUrl.pathname || '/';
     if(conInfo._SERVER.SCRIPT_NAME.charAt(0) != '/')
-      conInfo._SERVER.SCRIPT_NAME = '/' + conInfo._SERVER.SCRIPT_NAME;   
+      conInfo._SERVER.SCRIPT_NAME = '/' + conInfo._SERVER.SCRIPT_NAME;
     conInfo._SERVER.PHP_SELF = conInfo._SERVER.SCRIPT_NAME;
     conInfo._SERVER.SCRIPT_FILENAME = conInfo._SERVER.DOCUMENT_ROOT
     + conInfo._SERVER.SCRIPT_NAME;
 
-    if(request._parsedUrl.host)   
-      conInfo._SERVER.SERVER_HOST = request._parsedUrl.host; 
-  }    
+    if(request._parsedUrl.host)
+      conInfo._SERVER.SERVER_HOST = request._parsedUrl.host;
+  }
 
   if(typeof extReq.headers === 'object')
       for(var key in extReq.headers)
-        conInfo._SERVER['HTTP_' + key.toUpperCase().replace('-','_')] 
+        conInfo._SERVER['HTTP_' + key.toUpperCase().replace('-','_')]
           = extReq.headers[key];
 
   if(typeof conInfo._SERVER.HTTP_REFERER !== 'undefined'){
     var refererUrl = url.parse(conInfo._SERVER.HTTP_REFERER);
     conInfo._SERVER.SERVER_PORT = refererUrl.port;
-    conInfo._SERVER.SERVER_ADDR = refererUrl.hostname;   
-    if(typeof conInfo._SERVER.SERVER_NAME === 'undefined' 
+    conInfo._SERVER.SERVER_ADDR = refererUrl.hostname;
+    if(typeof conInfo._SERVER.SERVER_NAME === 'undefined'
       || conInfo._SERVER.SERVER_NAME.length == 0)
       conInfo._SERVER.SERVER_NAME = refererUrl.hostname;
-  }  
+  }
 
   if(typeof conInfo._SERVER.HTTP_COOKIE !== 'undefined'){
     conInfo._SERVER.HTTP_COOKIE_PARSE_RAW = conInfo._SERVER.HTTP_COOKIE;
@@ -702,15 +702,15 @@ sphp._getConInfo=function(request){
     }
   }
 
-  if(typeof request.body !== 'object' && request.body) 
-    try{ 
+  if(typeof request.body !== 'object' && request.body)
+    try{
       conInfo._POST = JSON.parse(request.body);
     }catch(e){}
-  else      
+  else
     conInfo._POST = request.body || {};
 
   conInfo._REQUEST = Object.assign({}, conInfo._GET, conInfo._POST, conInfo._COOKIE);
- 
+
   if(request.session)
     conInfo._SERVER.SESSION = request.session;
 

--- a/sphp.js
+++ b/sphp.js
@@ -59,7 +59,12 @@ sphp.superglobals = {
 //  ,_ENV: JSON.parse(JSON.stringify(process.env))
 };
 
-sphp.cgiEngine='php-cgi';
+if (/^win/.test(process.platform)) {
+    sphp.cgiEngine = 'php-cgi.exe';
+} else {
+    sphp.cgiEngine = 'php-cgi';
+}
+
 sphp.minSpareWorkers=10;
 sphp.maxWorkers=20;
 sphp.stepDowntime=360;

--- a/test/doc_root/phpinfo.php
+++ b/test/doc_root/phpinfo.php
@@ -1,0 +1,3 @@
+<?php
+    phpinfo();
+?>

--- a/test/testexpress.js
+++ b/test/testexpress.js
@@ -7,11 +7,11 @@ var request = require('request');
 var express = require('express');
 var sphp = require('../sphp');
 
+var serving = false;
 describe('Test Express only', function() {
     before('Setup Server', function (_done) {
         this.timeout(600000); // because of first install from npm
 
-        var serving = false;
         var app = express();
         if (process.env.PHP_PATH && process.env.PHP_PATH !== "") {
             sphp.cgiEngine = process.env.PHP_PATH;

--- a/test/testexpress.js
+++ b/test/testexpress.js
@@ -4,7 +4,7 @@ var expect = require('chai').expect;
 var request = require('request');
 
 var express = require('express');
-var sphp = require('sphp');
+var sphp = require('../sphp');
 
 describe('Test Express only', function() {
     before('Setup Server', function (_done) {

--- a/test/testexpress.js
+++ b/test/testexpress.js
@@ -16,13 +16,14 @@ describe('Test Express only', function() {
             sphp.cgiEngine = process.env.PHP_PATH;
         }
 
+        var doc_root = __dirname + path.sep + 'doc_root/';
         var server = app.listen(20000, function() {
-            console.log('SPHP Server started on port 20000 with Doc-Root doc_root');
+            console.log('SPHP Server started on port 20000 with Doc-Root ' + doc_root);
             serving = true;
         });
 
-        app.use(sphp.express('doc_root'));
-        app.use(express.static('doc_root'));
+        app.use(sphp.express(doc_root));
+        app.use(express.static(doc_root));
 
         _done();
     });

--- a/test/testexpress.js
+++ b/test/testexpress.js
@@ -1,0 +1,54 @@
+/* jshint -W097 */// jshint strict:false
+/*jslint node: true */
+var expect = require('chai').expect;
+var request = require('request');
+
+var express = require('express');
+var sphp = require('sphp');
+
+describe('Test Express only', function() {
+    before('Setup Server', function (_done) {
+        this.timeout(600000); // because of first install from npm
+
+        var serving = false;
+        var app = express();
+        if (process.env.PHP_PATH && process.env.PHP_PATH !== "") {
+            sphp.cgiEngine = process.env.PHP_PATH;
+        }
+
+        var server = app.listen(20000, function() {
+            console.log.info('SPHP Server started on port 20000 with Doc-Root doc_root');
+            serving = true;
+        });
+
+        app.use(sphp.express('doc_root'));
+        app.use(express.static('doc_root'));
+
+        _done();
+    });
+
+    it('Test phpinfo()', function (done) {
+        request('http://127.0.0.1:20000/phpinfo.php', function (error, response, body) {
+            console.log('BODY: ' + body);
+            expect(serving).to.be.true;
+            expect(error).to.be.not.ok;
+            expect(body.indexOf('<title>phpinfo()</title>')).to.be.not.equal(-1);
+            expect(response.statusCode).to.equal(200);
+            done();
+        });
+    });
+
+    after('Stop Server', function (done) {
+        this.timeout(10000);
+        try {
+            if (serving) {
+                app.close();
+                console.log.info('SPHP Server stopped');
+            }
+            if (callback) callback();
+        } catch (e) {
+            if (callback) callback();
+        }
+
+    });
+});

--- a/test/testexpress.js
+++ b/test/testexpress.js
@@ -17,7 +17,7 @@ describe('Test Express only', function() {
         }
 
         var server = app.listen(20000, function() {
-            console.log.info('SPHP Server started on port 20000 with Doc-Root doc_root');
+            console.log('SPHP Server started on port 20000 with Doc-Root doc_root');
             serving = true;
         });
 
@@ -43,12 +43,10 @@ describe('Test Express only', function() {
         try {
             if (serving) {
                 app.close();
-                console.log.info('SPHP Server stopped');
+                console.log('SPHP Server stopped');
             }
-            if (callback) callback();
         } catch (e) {
-            if (callback) callback();
         }
-
+        done();
     });
 });

--- a/test/testexpress.js
+++ b/test/testexpress.js
@@ -1,6 +1,7 @@
 /* jshint -W097 */// jshint strict:false
 /*jslint node: true */
 var expect = require('chai').expect;
+var path = require('path');
 var request = require('request');
 
 var express = require('express');


### PR DESCRIPTION
Please check and accept the testing commit first. Or only accept this one, but follow things described there first!!

This PR contains the minimum fix needed to get Windows-compatibilty. The reason is Line 73 of sphp.js where you search the last "/" in the path ... on windows it is the other separator :-) I replaced it with "path.sep" and it worked.
Other changes are only whitespace stuff my IDE did (sorry for that) when saving.

With this testing also get green in appveyor:
https://ci.appveyor.com/project/Apollon77/sphp/build/test-13